### PR TITLE
New structure folders for crowdin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Project related files
 /i18n
+/user_documentation
+/help_pages_documentation
+/website_elements
 
 # IDE & System Related Files
 .buildpath

--- a/bin/crowdinup.sh
+++ b/bin/crowdinup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This will copy the files to translate after we run - npm run docusaurus write-translations - to
+# the desire folders structure we want to upload to crowdin
+
+# to-do
+# Check if folders exist. If yes, delete it for create it again.
+# After up the folders to crowdin, this folders are not longer neccessary
+
+# we need create each folder in the root for get at crowdin the structure we want
+# if we create a parent folder for the 3 folders, then the structure will be the same at crowdin
+user_documentation="user_documentation"
+help_pages_documentation="help_pages_documentation"
+website="website_elements"
+
+echo "Copy all versions content from /versioned_docs/ to user_documentation/"
+mkdir $user_documentation
+cp -rv versioned_docs/* $user_documentation/
+
+echo "Copy all versions content from /help_versioned_docs/ to help-page/"
+mkdir $help_pages_documentation
+cp -rv help_versioned_docs/* $help_pages_documentation/
+
+echo "Create the website folder and copy the .json files"
+mkdir -p $website/$user_documentation/
+mkdir -p $website/$help_pages_documentation/
+mkdir -p $website/theme/
+cp -rv i18n/en/docusaurus-plugin-content-docs/* $website/$user_documentation/
+cp -rv i18n/en/docusaurus-plugin-content-docs-help/* $website/$help_pages_documentation/
+cp -rv i18n/en/docusaurus-theme-classic/* $website/theme/
+cp -rv i18n/en/code.json $website/

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,69 +1,42 @@
 # https://developer.crowdin.com/configuration-file/
 # https://docusaurus.io/docs/i18n/crowdin
 
-# Crowdin credentials
-#
+# CROWDIN CREDENTIALS
 project_id: 114
 api_token_env: CROWDIN_PERSONAL_TOKEN
 base_path: '.'
 base_url: 'https://joomla.crowdin.com'
 
-#
-# Choose file structure in Crowdin
-#
 'preserve_hierarchy': true
 
-#
-# Files configuration
-#
+# skip_untranslated_strings – Only translated strings will be included in the exported translation files.
+# skip_untranslated_files – Only translated files will be included in the exported translation archive.
+# export_only_approved – Only texts that are both translated and approved will be included in the exported translation files.
+
 files:
-  #
-  # Source JSON translation files filter when: npm run crowdin upload
-  #
-  - 'source': '/i18n/en/**/*'
+  # WEBSITE ELEMENTS
+  - 'source': '/website_elements/help_pages_documentation/**/*'
+    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs-help/%original_file_name%'
+    'update_option': 'update_without_changes'
 
-    #
-    # Where translations will be placed when: npm run crowdin download
-    #
-    'translation': '/i18n/%two_letters_code%/**/%original_file_name%'
+  - 'source': '/website_elements/user_documentation/**/*'
+    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs/%original_file_name%'
+    'update_option': 'update_without_changes'
 
-    #
-    # Source Docs Markdown files filter when: npm run crowdin upload
-    #
-  - 'source': '/docs/**/*'
+  - 'source': '/website_elements/theme/**/*'
+    'translation': '/i18n/%two_letters_code%/docusaurus-theme-classic/%original_file_name%'
+    'update_option': 'update_without_changes'
 
-    #
-    # Where translations will be placed when: npm run crowdin download
-    #
-    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%'
+  - 'source': '/website_elements/code.json'
+    'translation': '/i18n/%two_letters_code%/%original_file_name%'
+    'update_option': 'update_without_changes'
 
-    #
-    # Source Docs Markdown files filter when: npm run crowdin upload
-    #
-  - 'source': '/help/**/*'
+  # USER DOCUMENTATION
+  - 'source': '/user_documentation/**/*'
+    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs/**/%original_file_name%'
+    'update_option': 'update_without_changes'
 
-    #
-    # Where translations will be placed when: npm run crowdin download
-    #
-    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs-help/current/**/%original_file_name%'
-
-    #
-    # Source Docs Markdown files filter when: npm run crowdin upload
-    #
-  - 'source': '/versioned_docs/**/*'
-
-    #
-    # Where translations will be placed when: npm run crowdin download
-    #
-    'translation':
-      '/i18n/%two_letters_code%/docusaurus-plugin-content-docs/current/**/%original_file_name%'
-
-      #
-    # Source Docs Markdown files filter when: npm run crowdin upload
-    #
-  - 'source': '/help_versioned_docs/**/*'
-
-    #
-    # Where translations will be placed when: npm run crowdin download
-    #
-    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs-help/current/**/%original_file_name%'
+  # HELP PAGES DOCUMENTATION
+  - 'source': '/help_pages_documentation/**/*'
+    'translation': '/i18n/%two_letters_code%/docusaurus-plugin-content-docs-help/**/%original_file_name%'
+    'update_option': 'update_without_changes'


### PR DESCRIPTION
After run `npm run write-translations`, using a .sh script we create the desire structure folders for crowdin, with the files to upload. `crowdin.yml` was adjusted for support these folders.

Now we need sign the .sh in the drone and run it right after `npm run write-translations`

![image](https://user-images.githubusercontent.com/3956472/221480491-9c43ce16-fd9f-4eb0-a7a3-ec3a5a02e151.png)
